### PR TITLE
Single value instead of an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Change configuration in an initializer if you need:
 
 ```ruby
 IoMonitor.configure do |config|
-  config.publish = [:logs, :notifications, :prometheus] # defaults to :logs
+  config.publish = :notifications # defaults to :logs. Possible publishers: [:logs, :notifications, :prometheus]
   config.warn_threshold = 0.8 # defaults to 0
   config.adapters = [:active_record, :net_http, :redis] # defaults to [:active_record]
 end


### PR DESCRIPTION
Slight update to the documentation so that it becomes clear we need to pass a single value instead of an array.