### PR TITLE
Fix net/http adapter and an issue with nil responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,10 @@ if (rails_version = ENV["RAILS_VERSION"])
 end
 # standard: enable Bundler/DuplicatedGem
 
+gem "rails", "~> 7.1"
 gem "rake", "~> 13.0"
-gem "rspec", "~> 3.0"
-gem "rspec-rails", "~> 5.0"
+gem "rspec", "~> 3.13.0"
+gem "rspec-rails", "~> 7.1"
 gem "with_model", "~> 2.0"
 gem "database_cleaner-active_record", "~> 2.0"
 gem "standard", "~> 1.18.0"
@@ -29,4 +30,4 @@ gem "pry"
 gem "webmock", "~> 3.14"
 
 # Dummy app dependencies
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", ">= 2.1"

--- a/lib/io_monitor/controller.rb
+++ b/lib/io_monitor/controller.rb
@@ -37,7 +37,7 @@ module IoMonitor
         data[source] = aggregator.get(source)
       end
 
-      data[:response] = payload[:response].body.bytesize
+      data[:response] = payload[:response]&.body&.bytesize || 0
     end
 
     private

--- a/lib/io_monitor/patches/net_http_adapter_patch.rb
+++ b/lib/io_monitor/patches/net_http_adapter_patch.rb
@@ -3,8 +3,8 @@
 module IoMonitor
   module NetHttpAdapterPatch
     def request(*args, &block)
-      super do |response|
-        if response.body && IoMonitor.aggregator.active?
+      super.tap do |response|
+        if response&.body && IoMonitor.aggregator.active?
           IoMonitor.aggregator.increment(NetHttpAdapter.kind, response.body.bytesize)
         end
       end

--- a/spec/dummy/app/controllers/fake_controller.rb
+++ b/spec/dummy/app/controllers/fake_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FakeController < ApplicationController
+  include IoMonitor::Controller
+
+  def fake
+    raise ActionController::RoutingError.new("Fake")
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get "/fake", to: "fake#fake"
 end

--- a/spec/io_monitor/controller_spec.rb
+++ b/spec/io_monitor/controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe IoMonitor::Controller, type: :controller do
 end
 
 RSpec.describe "when response is nil", type: :request do
-  pending "does not fail" do
+  it "does not fail" do
     get "/fake"
 
     expect(response).to be_not_found

--- a/spec/io_monitor/controller_spec.rb
+++ b/spec/io_monitor/controller_spec.rb
@@ -133,3 +133,11 @@ RSpec.describe IoMonitor::Controller, type: :controller do
     end
   end
 end
+
+RSpec.describe "when response is nil", type: :request do
+  pending "does not fail" do
+    get "/fake"
+
+    expect(response).to be_not_found
+  end
+end


### PR DESCRIPTION
This PR fixes 2 issues:

1. Prepending `Net::HTTP` with `NetHttpAdapterPatch` may cause errors if another tool (e.g. [faraday](https://github.com/lostisland/faraday-net_http/blob/main/lib/faraday/adapter/net_http.rb#L113C1-L118C1)) passes a block to `Net::HTTP` request.
2. In some cases (good examples are invalid params, especially invalid queries for GraphQL, or just `raise` from an action) we will have a `nil` response in `process_action.action_controller` event payload. I think we can just treat it as an empty response, using 0 as body size.
